### PR TITLE
fix: peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,10 +96,10 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.0",
-    "@types/react-dom": "^16.8.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "@types/react": "^16.x || 17.x",
+    "@types/react-dom": "^16.x || 17.x",
+    "react": "^16.x || 17.x",
+    "react-dom": "^16.x || 17.x"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This updates the `package.json` to not have a hard version of 16.x for react in the peer deps section.